### PR TITLE
Upgrade war, ear and ejb plugins to JDK 9+ compatible versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,12 @@
       <dependency.plugin.version>2.10</dependency.plugin.version>
       <deploy.plugin.version>2.8.2</deploy.plugin.version>
       <embedded.glassfish.plugin.version>3.1.1</embedded.glassfish.plugin.version>
-      <ear.plugin.version>2.10.1</ear.plugin.version>
+      <ear.plugin.version>3.0.0</ear.plugin.version>
       <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
-      <ejb.plugin.version>2.5.1</ejb.plugin.version>
+      <ejb.plugin.version>3.0.0</ejb.plugin.version>
       <exec.plugin.version>1.5.0</exec.plugin.version>
       <findbugs.plugin.version>3.0.4</findbugs.plugin.version>
+      <gmavenplus.plugin.version>1.6</gmavenplus.plugin.version>
       <gpg.plugin.version>1.6</gpg.plugin.version>
       <install.plugin.version>2.5.2</install.plugin.version>
       <jar.plugin.version>3.0.2</jar.plugin.version>
@@ -90,7 +91,7 @@
       <source.plugin.version>3.0.1</source.plugin.version>
       <surefire.version>2.19.1</surefire.version>
       <tomcat.plugin.version>1.1</tomcat.plugin.version>
-      <war.plugin.version>2.6</war.plugin.version>
+      <war.plugin.version>3.2.0</war.plugin.version>
 
       <!-- ***************** -->
       <!-- Repository Deployment URLs -->
@@ -532,6 +533,11 @@
                      </goals>
                   </execution>
                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>${gmavenplus.plugin.version}</version>
             </plugin>
          </plugins>
       </pluginManagement>


### PR DESCRIPTION
These are used in Weld examples.