### PR TITLE
Remove enforcer JDK rule.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,20 +304,6 @@
                <version>${enforcer.plugin.version}</version>
                <executions>
                   <execution>
-                     <id>enforce-java-version</id>
-                     <goals>
-                        <goal>enforce</goal>
-                     </goals>
-                     <configuration>
-                        <rules>
-                           <requireJavaVersion>
-                              <message>To build this project JDK ${jdk.min.version} (or greater) is required. Please install it.</message>
-                              <version>${jdk.min.version}</version>
-                           </requireJavaVersion>
-                        </rules>
-                     </configuration>
-                  </execution>
-                  <execution>
                      <id>enforce-maven-version</id>
                      <goals>
                         <goal>enforce</goal>


### PR DESCRIPTION
Removes the rule to only build with JDK 11 because we only need this for core-impl. The rest (mainly tests) can and should still be executeable with 8.