### PR TITLE
Update CI setup for this repo

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -102,8 +102,8 @@ jobs:
               java-version: 11,
           }
           - {
-            name: "17",
-            java-version: 17,
+            name: "21",
+            java-version: 21,
           }
     steps:
       - name: Checkout Weld Parent repo
@@ -164,11 +164,11 @@ jobs:
       matrix:
         java:
           - { name: "11",
-              java-version: 17,
+              java-version: 11,
           }
           - {
-            name: "17",
-            java-version: 17,
+            name: "21",
+            java-version: 21,
           }
     steps:
       - name: Checkout Weld Parent repo
@@ -232,8 +232,8 @@ jobs:
               java-version: 11,
           }
           - {
-            name: "17",
-            java-version: 17,
+            name: "21",
+            java-version: 21,
           }
     steps:
       - name: Checkout Weld Parent repo
@@ -289,8 +289,8 @@ jobs:
               java-version: 11,
           }
           - {
-            name: "17",
-            java-version: 11,
+            name: "21",
+            java-version: 21,
           }
     steps:
       - name: Checkout Weld Parent repo

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           JBOSS_HOME=`pwd`'/container/*'
           export JBOSS_HOME=`echo $JBOSS_HOME`
-          mvn clean package -Pupdate-jboss-as -Dtck -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -f core/jboss-as/pom.xml
+          mvn clean package -Pupdate-jboss-as -Pupdate-jakarta-apis -Dtck -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -f core/jboss-as/pom.xml
       - name: Zip Patched WildFly
         run: |
           cd container/


### PR DESCRIPTION
The CI intentionally takes weld/core and runs with tests there to verify changes in versions here won't break core builds.
However, that also means we need to apply same workaround as in `core` in terms of patching WFLY to have EE11 jars that we expect there (CDI, interceptors, ...).